### PR TITLE
ValuePlug : Avoid unnecessary reference counting

### DIFF
--- a/include/Gaffer/NumericPlug.inl
+++ b/include/Gaffer/NumericPlug.inl
@@ -42,7 +42,8 @@ namespace Gaffer
 template<typename T>
 inline T NumericPlug<T>::getValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	return getObjectValue<DataType>( precomputedHash )->readable();
+	IECore::ConstObjectPtr owner;
+	return getObjectValue<DataType>( owner, precomputedHash )->readable();
 }
 
 } // namespace Gaffer

--- a/include/Gaffer/TypedObjectPlug.inl
+++ b/include/Gaffer/TypedObjectPlug.inl
@@ -42,7 +42,17 @@ namespace Gaffer
 template<class T>
 inline typename TypedObjectPlug<T>::ConstValuePtr TypedObjectPlug<T>::getValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	return getObjectValue<ValueType>( precomputedHash );
+	IECore::ConstObjectPtr owner;
+	const ValueType *value = getObjectValue<ValueType>( owner, precomputedHash );
+	if( owner )
+	{
+		// Avoid unnecessary reference count manipulations.
+		return boost::static_pointer_cast<const ValueType>( std::move( owner ) );
+	}
+	else
+	{
+		return ConstValuePtr( value );
+	}
 }
 
 } // namespace Gaffer

--- a/include/Gaffer/TypedPlug.inl
+++ b/include/Gaffer/TypedPlug.inl
@@ -42,7 +42,8 @@ namespace Gaffer
 template<typename T>
 inline T TypedPlug<T>::getValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	return getObjectValue<DataType>( precomputedHash )->readable();
+	IECore::ConstObjectPtr owner;
+	return getObjectValue<DataType>( owner, precomputedHash )->readable();
 }
 
 } // namespace Gaffer

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -250,10 +250,10 @@ class GAFFER_API ValuePlug : public Plug
 		/// objects with each query - this allows it to support the calculation
 		/// of values in different contexts and on different threads.
 		///
-		/// The value is returned via a reference counted pointer, as
-		/// following return from getObjectValue(), it is possible that nothing
-		/// else references the value - the value could have come from the cache
-		/// and then have been immediately removed by another thread.
+		/// The value is returned directly via a raw pointer, allowing us to omit
+		/// reference counting for the common case where the plug owns its own static
+		/// (non-computed) value. In cases where the value will be computed, a
+		/// a reference must be taken, so `owner` is assigned to keep the value alive.
 		///
 		/// If a precomputed hash is available it may be passed to avoid computing
 		/// it again unnecessarily.
@@ -261,6 +261,9 @@ class GAFFER_API ValuePlug : public Plug
 		/// > Caution : Passing an incorrect `precomputedHash` has dire consequences,
 		/// so use with care. The hash must be the direct result of `ValuePlug::hash()`,
 		/// so this feature is not suitable for use in classes that override that method.
+		template<typename T = IECore::Object>
+		const T *getObjectValue( IECore::ConstObjectPtr &owner, const IECore::MurmurHash *precomputedHash = nullptr ) const;
+		/// \deprecated
 		template<typename T = IECore::Object>
 		boost::intrusive_ptr<const T> getObjectValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 		/// Should be called by derived classes when they wish to set the plug
@@ -279,6 +282,8 @@ class GAFFER_API ValuePlug : public Plug
 		class ComputeProcess;
 		class SetValueAction;
 
+		const IECore::Object *getValueInternal( IECore::ConstObjectPtr &owner, const IECore::MurmurHash *precomputedHash = nullptr ) const;
+		/// \deprecated
 		IECore::ConstObjectPtr getValueInternal( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 		void setValueInternal( IECore::ConstObjectPtr value, bool propagateDirtiness );
 		void childAddedOrRemoved();

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -700,6 +700,24 @@ class ValuePlugTest( GafferTest.TestCase ) :
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferTest.parallelGetValue( node["plug"], 10000000 )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testStaticStringValuePerformance( self ) :
+
+		node = Gaffer.Node()
+		node["plug"] = Gaffer.StringPlug()
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferTest.parallelGetValue( node["plug"], 10000000 )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testStaticObjectValuePerformance( self ) :
+
+		node = Gaffer.Node()
+		node["plug"] = Gaffer.ObjectPlug( defaultValue = IECore.IntVectorData() )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferTest.parallelGetValue( node["plug"], 10000000 )
+
 	def testIsSetToDefault( self ) :
 
 		n1 = GafferTest.AddNode()

--- a/src/Gaffer/StringPlug.cpp
+++ b/src/Gaffer/StringPlug.cpp
@@ -108,7 +108,8 @@ void StringPlug::setValue( const std::filesystem::path &value )
 
 std::string StringPlug::getValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	ConstStringDataPtr s = getObjectValue<StringData>( precomputedHash );
+	ConstObjectPtr owner;
+	const StringData *s = getObjectValue<StringData>( owner, precomputedHash );
 
 	const bool performSubstitutions =
 		m_substitutions &&
@@ -146,7 +147,8 @@ IECore::MurmurHash StringPlug::hash() const
 
 	if( performSubstitutions )
 	{
-		ConstStringDataPtr s = getObjectValue<StringData>();
+		ConstObjectPtr owner;
+		const StringData *s = getObjectValue<StringData>( owner );
 		if( IECore::StringAlgo::hasSubstitutions( s->readable() ) )
 		{
 			IECore::MurmurHash result;

--- a/src/GafferImage/AtomicFormatPlug.cpp
+++ b/src/GafferImage/AtomicFormatPlug.cpp
@@ -55,7 +55,8 @@ GAFFER_PLUG_DEFINE_TEMPLATE_TYPE( GafferImage::AtomicFormatPlug, AtomicFormatPlu
 template<>
 Format AtomicFormatPlug::getValue( const IECore::MurmurHash *precomputedHash ) const
 {
-	ConstFormatDataPtr d = getObjectValue<FormatData>( precomputedHash );
+	IECore::ConstObjectPtr owner;
+	const FormatData *d = getObjectValue<FormatData>( owner, precomputedHash );
 	Format result = d->readable();
 	if( result.getDisplayWindow().isEmpty() && ( ( direction() == Plug::In && Process::current() ) || direction() == Plug::Out ) )
 	{

--- a/src/GafferTestModule/ValuePlugTest.cpp
+++ b/src/GafferTestModule/ValuePlugTest.cpp
@@ -40,6 +40,7 @@
 
 #include "Gaffer/Context.h"
 #include "Gaffer/NumericPlug.h"
+#include "Gaffer/StringPlug.h"
 #include "Gaffer/TypedObjectPlug.h"
 #include "Gaffer/ValuePlug.h"
 
@@ -125,18 +126,22 @@ void GafferTestModule::bindValuePlugTest()
 {
 	def( "repeatGetValue", &repeatGetValue<IntPlug> );
 	def( "repeatGetValue", &repeatGetValue<FloatPlug> );
+	def( "repeatGetValue", &repeatGetValue<StringPlug> );
 	def( "repeatGetValue", &repeatGetValue<ObjectPlug> );
 	def( "repeatGetValue", &repeatGetValue<PathMatcherDataPlug> );
 	def( "repeatGetValue", &repeatGetValueWithVar<IntPlug> );
 	def( "repeatGetValue", &repeatGetValueWithVar<FloatPlug> );
+	def( "repeatGetValue", &repeatGetValueWithVar<StringPlug> );
 	def( "repeatGetValue", &repeatGetValueWithVar<ObjectPlug> );
 	def( "repeatGetValue", &repeatGetValueWithVar<PathMatcherDataPlug> );
 	def( "parallelGetValue", &parallelGetValue<IntPlug> );
 	def( "parallelGetValue", &parallelGetValue<FloatPlug> );
+	def( "parallelGetValue", &parallelGetValue<StringPlug> );
 	def( "parallelGetValue", &parallelGetValue<ObjectPlug> );
 	def( "parallelGetValue", &parallelGetValue<PathMatcherDataPlug> );
 	def( "parallelGetValue", &parallelGetValueWithVar<IntPlug> );
 	def( "parallelGetValue", &parallelGetValueWithVar<FloatPlug> );
+	def( "parallelGetValue", &parallelGetValueWithVar<StringPlug> );
 	def( "parallelGetValue", &parallelGetValueWithVar<ObjectPlug> );
 	def( "parallelGetValue", &parallelGetValueWithVar<PathMatcherDataPlug> );
 }


### PR DESCRIPTION
When `getObjectValue()` returns `m_staticValue`, the caller does not need to own a reference, because it is guaranteed to be kept alive by the plug itself. The caller only needs to own a reference to computed values, which may not be cached, or may be evicted from the cache on a secondard thread.

This yields the following performance improvements :

- testHashCacheOverhead (GafferTest.ValuePlugTest.ValuePlugTest) : was 1.15s now 1.05s (9% reduction)
- testStaticNumericValuePerformance (GafferTest.ValuePlugTest.ValuePlugTest) : was 0.76s now 0.01s (99% reduction)
- testStaticObjectValuePerformance (GafferTest.ValuePlugTest.ValuePlugTest) : was 0.78s now 0.72s (8% reduction)
- testStaticStringValuePerformance (GafferTest.ValuePlugTest.ValuePlugTest) : was 0.95s now 0.01s (99% reduction)
