### PR TITLE
CI : Run on Ubuntu 24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         include:
 
           - name: linux-gcc11
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:3.0.0
@@ -49,7 +49,7 @@ jobs:
             jobs: 4
 
           - name: linux-debug-gcc11
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             buildType: DEBUG
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:3.0.0

--- a/.github/workflows/versionCheck.yml
+++ b/.github/workflows/versionCheck.yml
@@ -9,7 +9,7 @@ jobs:
   check:
 
     name: Version check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
 

--- a/.github/workflows/whitespaceCheck.yml
+++ b/.github/workflows/whitespaceCheck.yml
@@ -2,7 +2,7 @@ name: Whitespace check
 on: [ pull_request ]
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Support for 20.04 is being removed from GitHub. We have the choice of 22.04 or 24.04, and updating to the latest gives us the longest period before we have to do this again.
